### PR TITLE
Fix service task for nested services.

### DIFF
--- a/tests/TestCase/Generator/Task/ServiceTaskTest.php
+++ b/tests/TestCase/Generator/Task/ServiceTaskTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) Florian Krämer
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Florian Krämer
+ * @link          https://github.com/burzum/cakephp-service-layer
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+declare(strict_types = 1);
+
+namespace Burzum\Cake\Test\TestCase\Generator\Task;
+
+use Burzum\Cake\Generator\Task\ServiceTask;
+use Cake\TestSuite\TestCase;
+
+class ServiceTaskTest extends TestCase
+{
+    /**
+     * testLocate
+     *
+     * @return void
+     */
+    public function testCollect()
+    {
+        $task = new ServiceTask();
+        $map = $task->collect();
+        $expected = [
+            '\Burzum\Cake\Service\ServiceAwareTrait::loadService(0)' => [
+                'Articles' => '\App\Service\ArticlesService::class',
+                'Test' => '\App\Service\TestService::class',
+                'Sub/Folder/Nested' => '\App\Service\Sub\Folder\NestedService::class',
+            ],
+        ];
+        $this->assertSame($expected, $map);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,22 +1,71 @@
 <?php
-/**
- * Test suite bootstrap
- *
- * This function is used to find the location of CakePHP whether CakePHP
- * has been installed as a dependency of the plugin, or the plugin is itself
- * installed as a dependency of an application.
- */
-$findRoot = function ($root) {
-    do {
-        $lastRoot = $root;
-        $root = dirname($root);
-        if (is_dir($root . '/vendor/cakephp/cakephp')) {
-            return $root;
-        }
-    } while ($root !== $lastRoot);
-    throw new Exception('Cannot find the root of the application, unable to run tests');
-};
-$root = $findRoot(__FILE__);
-unset($findRoot);
-chdir($root);
-require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+define('ROOT', dirname(__DIR__));
+define('APP_DIR', 'src');
+// Point app constants to the test app.
+define('TEST_ROOT', ROOT . DS . 'tests' . DS . 'test_app' . DS);
+define('APP', TEST_ROOT . APP_DIR . DS);
+define('TEST_FILES', ROOT . DS . 'tests' . DS . 'test_files' . DS);
+define('TMP', ROOT . DS . 'tmp' . DS);
+if (!is_dir(TMP)) {
+    mkdir(TMP, 0770, true);
+}
+define('CONFIG', ROOT . DS . 'config' . DS);
+define('LOGS', TMP . 'logs' . DS);
+define('CACHE', TMP . 'cache' . DS);
+define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
+define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
+define('CAKE', CORE_PATH . APP_DIR . DS);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+require CORE_PATH . 'config/bootstrap.php';
+
+Configure::write('App', [
+    'namespace' => 'App',
+]);
+Configure::write('debug', true);
+
+$cache = [
+    'default' => [
+        'engine' => 'File'
+    ],
+    '_cake_core_' => [
+        'className' => 'File',
+        'prefix' => 'crud_myapp_cake_core_',
+        'path' => CACHE . 'persistent/',
+        'serialize' => true,
+        'duration' => '+10 seconds'
+    ],
+    '_cake_model_' => [
+        'className' => 'File',
+        'prefix' => 'crud_my_app_cake_model_',
+        'path' => CACHE . 'models/',
+        'serialize' => 'File',
+        'duration' => '+10 seconds'
+    ]
+];
+Cache::setConfig($cache);
+
+// Ensure default test connection is defined
+if (!getenv('db_class')) {
+    putenv('db_class=Cake\Database\Driver\Sqlite');
+    putenv('db_dsn=sqlite::memory:');
+}
+
+Cake\Datasource\ConnectionManager::setConfig('test', [
+    'className' => 'Cake\Database\Connection',
+    'driver' => getenv('db_class'),
+    'dsn' => getenv('db_dsn'),
+    'database' => getenv('db_database'),
+    'username' => getenv('db_username'),
+    'password' => getenv('db_password'),
+    'timezone' => 'UTC',
+    'quoteIdentifiers' => true,
+    'cacheMetadata' => true,
+]);


### PR DESCRIPTION
The collecting now properly detects also nested services:
```
[
  "Bar" => "App\Service\BarService"
  "Foo" => "App\Service\FooService"
  "Bar/Baz" => "App\Service\Bar\BazService"
  "Bar/BarBaz/BarBaz" => "App\Service\Bar\BarBaz\BarBazService"
]
```
etc