### PR TITLE
Fix reusability for looped loadService() call.

### DIFF
--- a/src/Service/ServiceAwareTrait.php
+++ b/src/Service/ServiceAwareTrait.php
@@ -56,7 +56,7 @@ trait ServiceAwareTrait
             $name = substr($name, strrpos($name, '/') + 1);
         }
 
-        if (isset($this->{$name})) {
+        if ($assignProperty && isset($this->{$name})) {
             return $this->{$name};
         }
 

--- a/src/Service/ServiceAwareTrait.php
+++ b/src/Service/ServiceAwareTrait.php
@@ -50,12 +50,6 @@ trait ServiceAwareTrait
      */
     public function loadService($service, array $constructorArgs = [], $assignProperty = true)
     {
-        $serviceInstance = $this->getServiceLocator()->load($service, $constructorArgs);
-
-        if (!$assignProperty) {
-            return $serviceInstance;
-        }
-
         list(, $name) = pluginSplit($service);
 
         if (strpos($name, '/') !== false) {
@@ -63,7 +57,13 @@ trait ServiceAwareTrait
         }
 
         if (isset($this->{$name})) {
-            trigger_error(__CLASS__ . '::$%s is already in use.', E_USER_WARNING);
+            return $this->{$name};
+        }
+
+        $serviceInstance = $this->getServiceLocator()->load($service, $constructorArgs);
+
+        if (!$assignProperty) {
+            return $serviceInstance;
         }
 
         $this->{$name} = $serviceInstance;

--- a/tests/TestCase/Service/ServiceLocatorTest.php
+++ b/tests/TestCase/Service/ServiceLocatorTest.php
@@ -37,6 +37,20 @@ class ServiceLocatorTest extends TestCase
     }
 
     /**
+     * testLocate multiple
+     *
+     * @return void
+     */
+    public function testLocateMultiple()
+    {
+        $locator = new ServiceLocator();
+        $service = $locator->load('Test');
+        $service = $locator->load('Test');
+
+        $this->assertInstanceOf(TestService::class, $service);
+    }
+
+    /**
      * testLocate
      *
      * @return void


### PR DESCRIPTION
Simpler alternative to https://github.com/burzum/cakephp-service-layer/pull/14

Fixes https://github.com/burzum/cakephp-service-layer/issues/13

It also directly uses the prop then instead of always creating dummy object, so cleaner and more performant flow here.