### PR TITLE
"Cannot unpack array with string keys" error thrown when passing assoc array to loadService

### DIFF
--- a/src/Service/ServiceLocator.php
+++ b/src/Service/ServiceLocator.php
@@ -80,6 +80,8 @@ class ServiceLocator extends ObjectRegistry
             return new $class();
         }
 
-        return new $class(...array_values($config));
+        $args = array_values((array)$config);
+
+        return new $class(...$args);
     }
 }

--- a/src/Service/ServiceLocator.php
+++ b/src/Service/ServiceLocator.php
@@ -80,6 +80,6 @@ class ServiceLocator extends ObjectRegistry
             return new $class();
         }
 
-        return new $class(...$config);
+        return new $class(...array_values($config));
     }
 }

--- a/tests/TestCase/Service/ServiceLocatorTest.php
+++ b/tests/TestCase/Service/ServiceLocatorTest.php
@@ -74,4 +74,19 @@ class ServiceLocatorTest extends TestCase
         $locator = new ServiceLocator();
         $locator->load('DoesNotExist');
     }
+
+    /**
+     * testPassingClassName
+     *
+     * @return void
+     */
+    public function testPassingClassName()
+    {
+        $locator = new ServiceLocator();
+        $locator->load('Existing', [
+            'className' => TestService::class
+        ]);
+        $this->assertNull($locator->get('Test'));
+        $this->assertInstanceOf(TestService::class, $locator->get('Existing'));
+    }
 }


### PR DESCRIPTION
Code below is throwing "Cannot unpack array with string keys" error:
```
// In my controller
public function initialize()
{
    $this->loadService('Consumers', [
        'className' => 'UserManagement.Users'
    ]);
}
```

It throws since ServiceLocator::_create method tries to pass arguments into Service constructor by unpacking passed configuration.