### PR TITLE
Fix bug judgement of serviceLocator to domainModelLocator

### DIFF
--- a/src/DomainModel/DomainModelAwareTrait.php
+++ b/src/DomainModel/DomainModelAwareTrait.php
@@ -72,7 +72,7 @@ trait DomainModelAwareTrait
      */
     public function getDomainModelLocator()
     {
-        if (empty($this->serviceLocator)) {
+        if (empty($this->domainModelLocator)) {
             $class = $this->defaultDomainModelLocator;
             $this->domainModelLocator = new $class();
         }


### PR DESCRIPTION
I'm using `trait DomainModelAwareTrait` to load my domain model. I called `loadService` with constructor args within a **loop** and realize the loaded Domain Model being instantiated each time without error thrown. 

We expect the `RuntimeException: The "Article" alias has already been loaded.` for the example code below.

Eg:
```php
class ArticleService
{
    use DomainModelAwareTrait;
    
    public function loadArticles()
    {
        $this->Articles->find()->all()->each(function ($article) {
            $article = $this->loadService('Article', [$article->id]);
            .....
        });
```

```php
class Article
{
    /**
     * Article constructor.
     */
    public function __construct($id)
    {
        $this->id = $id;
    }
}
```