### PR TITLE
Allow also inherited loadService() annotating.

### DIFF
--- a/src/Annotator/ClassAnnotatorTask/ServiceAwareClassAnnotatorTask.php
+++ b/src/Annotator/ClassAnnotatorTask/ServiceAwareClassAnnotatorTask.php
@@ -20,11 +20,25 @@ class ServiceAwareClassAnnotatorTask extends AbstractClassAnnotatorTask implemen
      */
     public function shouldRun(string $path, string $content): bool
     {
-        if (!preg_match('#\buse ServiceAwareTrait\b#', $content)) {
+        if (preg_match('#\buse ServiceAwareTrait\b#', $content)) {
+            return true;
+        }
+
+        $className = $this->getClassName($path, $content);
+        if (!$className) {
             return false;
         }
 
-        return true;
+        try {
+            $object = new $className();
+            if (method_exists($object, 'loadService')) {
+                return true;
+            }
+        } catch (\Throwable $exception) {
+            // Do nothing
+        }
+
+        return false;
     }
 
     /**
@@ -80,5 +94,23 @@ class ServiceAwareClassAnnotatorTask extends AbstractClassAnnotatorTask implemen
         }
 
         return $annotations;
+    }
+
+    /**
+     * @param string $path Path to PHP class file
+     * @param string $content Content of PHP class file
+     *
+     * @return string|null
+     */
+    protected function getClassName(string $path, string $content): ?string
+    {
+        preg_match('#^namespace (.+)\b#m', $content, $matches);
+        if (!$matches) {
+            return null;
+        }
+
+        $className = pathinfo($path, PATHINFO_FILENAME);
+
+        return $matches[1] . '\\' . $className;
     }
 }


### PR DESCRIPTION
Follow https://github.com/dereuromark/cakephp-ide-helper/commit/d5c68b48bcc1d55672da6703cda816c676504af8

This works for example now when you have a

    class ReleaseTask extends Task

and the parent `Task` contains the trait and thus the method.
